### PR TITLE
Revert "Bump version for dependency updates"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,18 +1,6 @@
 TCP/IP Library Change Log
 =========================
 
-4.0.2
------
-
-  * Changes to dependencies:
-
-    - lib_ethernet: 3.0.3 -> 3.1.1
-
-      + Fixed issue with application filter data not being forwarded to clients
-        of 100Mb MACs
-      + Added VLAN tag stripping option to RT 100Mb Ethernet MAC configuration
-        interface
-
 4.0.1
 -----
 

--- a/lib_xtcp/module_build_info
+++ b/lib_xtcp/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 4.0.2
+VERSION = 4.0.1
 
 DEPENDENT_MODULES = lib_ethernet(>=3.0.3) lib_otpinfo(>=2.0.0)
 


### PR DESCRIPTION
This reverts commit cb48129001a4cb8162d627068b4255a8035f0c2f.

Dependency updates are no longer included in library changelogs, so this version bump is now redundant.
