### PR TITLE
lib_xtcp:  make lib_xtcp high performance by allowing sends more than

### DIFF
--- a/lib_xtcp/src/xtcp.xc
+++ b/lib_xtcp/src/xtcp.xc
@@ -127,11 +127,6 @@ void xtcp(chanend xtcp[n], size_t n,
 
   while (1) {
 
-    xtcpd_service_clients(xtcp, n);
-    xtcpd_check_connection_poll();
-    uip_xtcp_checkstate();
-    xtcp_process_udp_acks();
-
     unsafe {
     select {
     case !isnull(i_mii) => mii_incoming_packet(mii_info):
@@ -205,6 +200,12 @@ void xtcp(chanend xtcp[n], size_t n,
 
       xtcp_process_periodic_timer();
       break;
+    default:
+        xtcpd_service_clients(xtcp, n);
+        xtcpd_check_connection_poll();
+        uip_xtcp_checkstate();
+        xtcp_process_udp_acks();
+        break;
     }
     }
   }


### PR DESCRIPTION
10 per second.

Before this patch, lib_xtcp only calls

        xtcpd_service_clients(xtcp, n);
        xtcpd_check_connection_poll();
        uip_xtcp_checkstate();
        xtcp_process_udp_acks();

once every 100ms, which means that there is about 100ms delay between
the time a packet is requested to be sent with init_send, and when
packets are actually sent.  It only happens on the timeout.

By moving these statements into a default part of the while(1) select
statement, they are called continuously, which dramatically improves
performance.  However, this is still not a very good patch for 2
reasons:

Firstly, it's polling infinitely fast (well, as close as we can get),
which is bad for performance, and bad form all around.  And,
performance still is not very good.

I was able to pretty much saturate a 100MB connection by talking
directly to the MII port (got 87MBits/sec recorded with wireshark),
but this patch is only able to get about 30 MBits/sec, which is still
well below what the performance should be.

By comparison, the current state of lib_xtcp can only send about

1500 bytes * 10 packets/second * 8bits/byte / 1e6 bytes/mbyte =
0.12MBits/sec, so this patch provides a dramatic improvement, but stil
needs help.