### PR TITLE
Removed trailing forward slash in module_build_info

### DIFF
--- a/lib_xtcp/module_build_info
+++ b/lib_xtcp/module_build_info
@@ -7,7 +7,7 @@ MODULE_XCC_FLAGS = $(XCC_FLAGS) -DLWIP=1 -DUIP=2 -g -Os
 
 # Source directories
 # Note: only includes IPv4 of lwIP
-LWIP_SOURCE_DIRS = src src/xtcp_lwip/api src/xtcp_lwip/core/ src/xtcp_lwip/core/ipv4 src/xtcp_lwip/netif src/xtcp_lwip/xcore/src
+LWIP_SOURCE_DIRS = src src/xtcp_lwip/api src/xtcp_lwip/core src/xtcp_lwip/core/ipv4 src/xtcp_lwip/netif src/xtcp_lwip/xcore/src
 UIP_SOURCE_DIRS  = src src/xtcp_uip src/xtcp_uip/autoip src/xtcp_uip/dhcpc src/xtcp_uip/igmp
 
 # Include directories


### PR DESCRIPTION
Fixing build problems on windows