### PR TITLE
Removed trailing forward slash in module build info

### DIFF
--- a/lib_xtcp/module_build_info
+++ b/lib_xtcp/module_build_info
@@ -8,7 +8,7 @@ EXCLUDE_FILES += uip_arp.c autoip.c dhcp.c igmp.c rpl.c rpl-dag.c rpl-ext-header
                  rpl-icmp6.c rpl-mrhof.c rpl-of0.c rpl-timers.c
 
 else
-LWIP_SOURCE_DIRS = src/xtcp_lwip/api src/xtcp_lwip/core/ src/xtcp_lwip/core/ipv4 src/xtcp_lwip/netif src/xtcp_lwip/xcore/src
+LWIP_SOURCE_DIRS = src/xtcp_lwip/api src/xtcp_lwip/core src/xtcp_lwip/core/ipv4 src/xtcp_lwip/netif src/xtcp_lwip/xcore/src
 MBEDTLS_SOURCE_DIRS = src/xtcp_mbedtls/library
 XTCP_SOURCE_DIRS = src src/xtcp_uip/*
 EXCLUDE_FILES += uip-fw.c uip-neighbor.c


### PR DESCRIPTION
# Conflicts:
#	lib_xtcp/module_build_info