### PR TITLE
Corrected uips handling of UDP multicast

### DIFF
--- a/lib_xtcp/src/xtcp_uip/uip.h
+++ b/lib_xtcp/src/xtcp_uip/uip.h
@@ -958,7 +958,7 @@ void uip_ipaddr_copy(void *dest, const void *src);
  */
 #if !UIP_CONF_IPV6
 int uip_ipaddr_cmp(const void *addr1, const void *addr2);
-#define uip_ipaddr_is_multicast(addr) ((((u16_t *)addr)[0] & 0xff) == 224)
+#define uip_ipaddr_is_multicast(addr) ((((u16_t *)addr)[0] & 0xf0) == 0xe0)
 #else /* !UIP_CONF_IPV6 */
 #define uip_ipaddr_cmp(addr1, addr2) (memcmp(addr1, addr2, sizeof(uip_ip6addr_t)) == 0)
 

--- a/lib_xtcp/src/xtcp_uip/uip_arp.c
+++ b/lib_xtcp/src/xtcp_uip/uip_arp.c
@@ -378,8 +378,8 @@ uip_arp_out(struct uip_udp_conn *conn)
     IPBUF->ethhdr.dest.addr[0] = 0x01;
     IPBUF->ethhdr.dest.addr[1] = 0x00;
     IPBUF->ethhdr.dest.addr[2] = 0x5e;
-    IPBUF->ethhdr.dest.addr[3] = IPBUF->destipaddr[0] >> 8;
-    IPBUF->ethhdr.dest.addr[4] = IPBUF->destipaddr[1] & 0xf;
+    IPBUF->ethhdr.dest.addr[3] = (IPBUF->destipaddr[0] >> 8) & 0b01111111;
+    IPBUF->ethhdr.dest.addr[4] = IPBUF->destipaddr[1] & 0xff;
     IPBUF->ethhdr.dest.addr[5] = IPBUF->destipaddr[1] >> 8;
   }
   else  {


### PR DESCRIPTION
Original issue:
Using uip, when sending UDP multicast to a multicast address OTHER than 224.x.x.x no destination MAC would be present in the sent packet.

This should fix the issue.