### PR TITLE
Fix TCP close handling in lwIP mode

### DIFF
--- a/lib_xtcp/src/xtcp_lwip.xc
+++ b/lib_xtcp/src/xtcp_lwip.xc
@@ -581,6 +581,8 @@ lwip_tcp_event(void *unsafe arg,
     case LWIP_EVENT_RECV:
       if(p != NULL) {
         enqueue_event_and_notify(pcb->xtcp_conn.client_num, XTCP_RECV_DATA, &(pcb->xtcp_conn), p);
+      } else {
+        enqueue_event_and_notify(pcb->xtcp_conn.client_num, XTCP_CLOSED, &(pcb->xtcp_conn), NULL);
       }
       break;
 


### PR DESCRIPTION
A tcp connection being closed is signalled by lwIP using a receive event
with p == NULL. Before this commit those events were ignored by the
xtcp layer, which resulted in application code to never receive a
XTCP_CLOSED event from lib_xtcp.

This commit handles the case p == NULL and sends a XTCP_CLOSED to
the application.