### PR TITLE
Created MAC address callback for client to provide value.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     )
     string(
         name: 'INFR_APPS_VERSION',
-        defaultValue: 'v3.1.1',
+        defaultValue: 'v3.2.0',
         description: 'The infr_apps version'
     )
     choice(

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ lib_xtcp: TCP/IP Library
 :scope: General Use
 :description: TCP/IP Library
 :category: Networking
-:keywords: Ethernet, MAC, MII, RMII, RGMII, SMI, TCP, UDP
-:hardware: xcore.ai, xcore-200
+:keywords: Ethernet
+:devices: xcore.ai, xcore-200
 
 *******
 Summary

--- a/doc/rst/lib_xtcp.rst
+++ b/doc/rst/lib_xtcp.rst
@@ -489,6 +489,8 @@ by the library on build).
 
 .. doxygendefine:: CLIENT_QUEUE_SIZE
 
+.. doxygenfunction:: xtcp_configure_mac
+
 |newpage|
 
 .. _lib_xtcp_api:

--- a/examples/app_simple_echo/src/main.xc
+++ b/examples/app_simple_echo/src/main.xc
@@ -3,6 +3,7 @@
 
 #include <xs1.h>
 #include <platform.h>
+#include <string.h>
 #include <xscope.h>
 
 #include "app_udpecho.h"
@@ -51,11 +52,16 @@ static xtcp_ipconfig_t ipconfig = {
   {255, 255, 255,   0},  /* submask, 0 for DHCP */
   {0, 0, 0, 0},          /* Gateway */
 };
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
-static const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
 }
 
 int main()
@@ -93,7 +99,7 @@ int main()
     on tile[0]: xtcp_lwip(i_xtcp, NUM_TCP_CLIENTS,
                           null, // mii_if
                           i_cfg[CFG_TO_TCP], i_rx[ETH_TO_TCP], i_tx[ETH_TO_TCP],
-                          mac_address_phy, null, ipconfig);
+                          ipconfig);
 
     on tile[1]: udp_echo(i_xtcp[TCP_TO_APP_UDP]);
     on tile[1]: tcp_echo(i_xtcp[TCP_TO_APP_TCP]);

--- a/examples/app_simple_echo/src/test_tcp.py
+++ b/examples/app_simple_echo/src/test_tcp.py
@@ -27,7 +27,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.send(bytes(msg, "ascii"))
 
         chunk = sock.recv(20)
-        print("Revc'd message: " + str(chunk))
+        print("Recv'd message: " + str(chunk))
 
     except socket.timeout:
         print("No response received within the timeout period.")

--- a/examples/app_simple_echo/src/test_udp.py
+++ b/examples/app_simple_echo/src/test_udp.py
@@ -27,7 +27,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
         sock.send(bytes(msg, "ascii"))
 
         chunk = sock.recv(1500)
-        print("Revc'd message: " + str(chunk))
+        print("Recv'd message: " + str(chunk))
 
     except socket.timeout:
         print("No response received within the timeout period.")

--- a/examples/app_simple_webserver/src/main.xc
+++ b/examples/app_simple_webserver/src/main.xc
@@ -2,12 +2,13 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <platform.h>
+#include <string.h>
+
 #include "xk_eth_316_dual/board.h"
 #include "debug_print.h"
 #include "xtcp.h"
 #include "httpd.h"
 #include "smi.h"
-#include "otp_board_info.h"
 
 port p_smi_mdio = MDIO;
 port p_smi_mdc = MDC;
@@ -39,9 +40,6 @@ enum cfg_clients {
   NUM_CFG_CLIENTS
 };
 
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
-static unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
-
 // IP Config - change this to suit your network.  Leave with all
 // 0 values to use DHCP
 xtcp_ipconfig_t ipconfig = {
@@ -51,6 +49,13 @@ xtcp_ipconfig_t ipconfig = {
 };
 
 #define ETH_RX_BUFFER_SIZE_WORDS 1600
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
+}
 
 int main(void) {
   xtcp_if         i_xtcp[NUM_XTCP_CLIENTS];
@@ -87,7 +92,7 @@ int main(void) {
     // TCP component
     on tile[0]: xtcp_lwip(i_xtcp, NUM_XTCP_CLIENTS, null,
                           i_cfg[CFG_TO_XTCP], i_rx[ETH_TO_XTCP], i_tx[ETH_TO_XTCP],
-                          mac_address_phy, null, ipconfig);
+                          ipconfig);
 
     // HTTP server application
     on tile[0]: xhttpd(i_xtcp[XTCP_TO_HTTP]);

--- a/lib_xtcp/api/xtcp.h
+++ b/lib_xtcp/api/xtcp.h
@@ -7,8 +7,6 @@
 #include <mii.h>
 #include <smi.h>
 #include <ethernet.h>
-// TODO - remove dependency on OTP
-#include <otp_board_info.h>
 #include <xccompat.h>
 
 #include "xc2compat.h"
@@ -488,9 +486,6 @@ typedef interface xtcp_pbuf_if {
  *                      interface should be used to connect to it. Otherwise it should be set to null.
  *  \param i_eth_tx     If this component is connected to an MAC component in the Ethernet library then this
  *                      interface should be used to connect to it. Otherwise it should be set to null.
- *  \param mac_address  If this array is non-null then it will be used to set the MAC address of the component.
- *  \param otp_ports    If this port structure is non-null then the component will obtain the MAC address from OTP ROM.
- *                      See the OTP reading library user guide for details.
  *  \param ipconfig     This `xtcp_ipconfig_t` structure is used to determine the IP address configuration of the
  *                      component.
  */
@@ -500,10 +495,22 @@ void xtcp_lwip(SERVER_INTERFACE_ARRAY(xtcp_if, i_xtcp, n_xtcp),
                NULLABLE_CLIENT_INTERFACE(ethernet_cfg_if, i_eth_cfg),
                NULLABLE_CLIENT_INTERFACE(ethernet_rx_if, i_eth_rx),
                NULLABLE_CLIENT_INTERFACE(ethernet_tx_if, i_eth_tx),
-               CONST_NULLABLE_ARRAY_OF_SIZE(char, mac_address0, MACADDR_NUM_BYTES),
-               NULLABLE_REFERENCE_PARAM(otp_ports_t, otp_ports),
                REFERENCE_PARAM(xtcp_ipconfig_t, ipconfig));
 #endif /* __XC__ || __DOXYGEN__ */
+
+/** Configure the MAC address for a given network interface
+ * 
+ * This function is called by xtcp_lwip() during initialization to set the MAC address for the network interface.
+ * Define in the client application to provide a MAC address.
+ * 
+ * \param netif_id      The network interface ID to configure the MAC address for. Can be ignored for now as only 1 netif is currently supported.
+ * \param mac_address   The six-octet MAC address output parameter to set for the given network interface.
+ * 
+ * \note This is a weak function that must be overridden by the user to provide a custom MAC address configuration.
+ * \warning This function is called from the xtcp_lwip() task and may not be on the same tile as the client application. 
+ * Do not use shared memory or resources in this function.
+*/
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]);
 
 /** Copy an IP address data structure.
  */

--- a/lib_xtcp/lib_build_info.cmake
+++ b/lib_xtcp/lib_build_info.cmake
@@ -51,6 +51,7 @@ set(LIB_C_SRCS              src/client_queue.c
                             src/tcp_transport.c
                             src/udp_recv.c
                             src/dns_found.c
+                            src/xtcp_configure.c
                             ${XTCP_LWIP_CODE_LIST})
 
 set(LIB_XC_SRCS             src/xtcp_lwip.xc
@@ -66,8 +67,7 @@ set(LIB_INCLUDES            api
 set(LIB_DEPENDENT_MODULES   "lib_ethernet(4.1.0)"
                             "lib_logging(3.4.0)"
                             "lib_xassert(4.3.2)"
-                            "lib_random(1.3.1)"
-                            "lib_otpinfo(2.2.1)")
+                            "lib_random(1.3.1)")
 
 set(LIB_COMPILER_FLAGS      -g
                             -O3

--- a/lib_xtcp/src/xtcp_configure.c
+++ b/lib_xtcp/src/xtcp_configure.c
@@ -1,0 +1,15 @@
+// Copyright 2016-2025 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#include "xtcp.h"
+
+#include <string.h>
+
+#include "debug_print.h"
+#include "ethernet.h"
+
+__attribute__((weak)) void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  (void)netif_id;
+  memset(mac_address, 0, MACADDR_NUM_BYTES);
+  debug_printf("xtcp_configure_mac: Override this function to set a valid MAC address, returning zero MAC address\n");
+}

--- a/lib_xtcp/src/xtcp_lwip.xc
+++ b/lib_xtcp/src/xtcp_lwip.xc
@@ -174,8 +174,6 @@ void xtcp_lwip(server xtcp_if i_xtcp[n_xtcp], static const unsigned n_xtcp,
                client interface ethernet_cfg_if ?i_eth_cfg,
                client interface ethernet_rx_if ?i_eth_rx,
                client interface ethernet_tx_if ?i_eth_tx,
-               const uint8_t (&?mac_address)[MACADDR_NUM_BYTES],
-               otp_ports_t &?otp_ports,
                xtcp_ipconfig_t &ipconfig)
 {
   timer timers[NUM_TIMEOUTS];
@@ -189,13 +187,7 @@ void xtcp_lwip(server xtcp_if i_xtcp[n_xtcp], static const unsigned n_xtcp,
     period[i] = XS1_TIMER_KHZ;
   }
 
-  if (!isnull(mac_address)) {
-    memcpy(mac_address_phy, mac_address, MACADDR_NUM_BYTES);
-  } else if (!isnull(otp_ports)) {
-    otp_board_info_get_mac(otp_ports, 0, mac_address_phy);
-  } else {
-    fail("Must supply OTP ports or MAC address to xtcp component");
-  }
+  xtcp_configure_mac(0, mac_address_phy);
 
   if (!isnull(i_eth_cfg) && !isnull(i_mii)) {
     fail("Error: Cannot use both ethernet_cfg_if and mii_if at the same time");

--- a/tests/common/include/common.h
+++ b/tests/common/include/common.h
@@ -11,7 +11,6 @@
 
 #include "debug_print.h"
 #include "ethernet.h"
-#include "otp_board_info.h"
 #include "smi.h"
 
 // Defines

--- a/tests/xtcp_bombard_lwip/src/main.xc
+++ b/tests/xtcp_bombard_lwip/src/main.xc
@@ -5,6 +5,7 @@
 
 #include <xs1.h>
 #include <platform.h>
+#include <string.h>
 #include <xscope.h>
 
 #include "common.h"
@@ -34,15 +35,18 @@ xtcp_ipconfig_t ipconfig = {
     {255, 255, 255,   0},  // netmask    (eg 255,255,255,0)
     {0, 0, 0, 0}           // gateway    (eg 192,168,0,1)
 };
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your
-// desired address.
-static unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97,
-                                                           0x01, 0x02, 0x03};
 
 #define ETH_RX_BUFFER_SIZE_WORDS 1600
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
 }
 
 int main(void) {
@@ -69,7 +73,7 @@ int main(void) {
     on tile[0] : xtcp_lwip(i_xtcp, REFLECT_PROCESSES,
                            null,
                            i_cfg[CFG_TO_XTCP], i_rx[ETH_TO_XTCP], i_tx[ETH_TO_XTCP],
-                           mac_address_phy, null, ipconfig);
+                           ipconfig);
 
     // The simple udp reflector thread
     par(int i = 0; i < REFLECT_PROCESSES; i++) {

--- a/tests/xtcp_burst/src/main.xc
+++ b/tests/xtcp_burst/src/main.xc
@@ -5,6 +5,7 @@
 
 #include <xs1.h>
 #include <platform.h>
+#include <string.h>
 #include <xscope.h>
 
 #include "common.h"
@@ -34,14 +35,18 @@ xtcp_ipconfig_t ipconfig = {
     {255, 255, 255,   0},  // netmask    (eg 255,255,255,0)
     {0, 0, 0, 0}           // gateway    (eg 192,168,0,1)
 };
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your
-// desired address.
-static unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
 
 #define ETH_RX_BUFFER_SIZE_WORDS 1600
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
 }
 
 void busy_client(client xtcp_if i_xtcp, int start_port);
@@ -70,7 +75,7 @@ int main(void) {
     on tile[0] : xtcp_lwip(i_xtcp, REFLECT_PROCESSES,
                            null,
                            i_cfg[CFG_TO_XTCP], i_rx[ETH_TO_XTCP], i_tx[ETH_TO_XTCP],
-                           mac_address_phy, null, ipconfig);
+                           ipconfig);
 
     // The simple udp reflector thread
     par(int i = 0; i < REFLECT_PROCESSES; i++) {

--- a/tests/xtcp_tcp_connect/src/main.xc
+++ b/tests/xtcp_tcp_connect/src/main.xc
@@ -3,6 +3,7 @@
 
 #include <xs1.h>
 #include <platform.h>
+#include <string.h>
 #include <xscope.h>
 
 #include "app_tcp_connect.h"
@@ -54,11 +55,16 @@ static xtcp_ipconfig_t ipconfig = {
   {255, 255, 255,   0},  /* submask, 0 for DHCP */
   {0, 0, 0, 0},          /* Gateway */
 };
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
-static const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x33};
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x33};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
 }
 
 int main()
@@ -97,7 +103,7 @@ int main()
     on tile[1]: xtcp_lwip(i_xtcp, NUM_TCP_CLIENTS,
                           null, // mii_if
                           i_cfg[CFG_TO_TCP], i_rx[ETH_TO_TCP], i_tx[ETH_TO_TCP],
-                          mac_address_phy, null, ipconfig);
+                          ipconfig);
 
     on tile[1]: app_tcp_connect(i_xtcp[TCP_TO_APP_TCP]);
   }

--- a/tests/xtcp_udp_connect/src/main.xc
+++ b/tests/xtcp_udp_connect/src/main.xc
@@ -3,6 +3,7 @@
 
 #include <xs1.h>
 #include <platform.h>
+#include <string.h>
 #include <xscope.h>
 
 #include "app_udp_connect.h"
@@ -54,11 +55,16 @@ static xtcp_ipconfig_t ipconfig = {
   {255, 255, 255,   0},  /* submask, 0 for DHCP */
   {0, 0, 0, 0},          /* Gateway */
 };
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
-static const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x23};
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x23};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
 }
 
 int main()
@@ -97,7 +103,7 @@ int main()
     on tile[1]: xtcp_lwip(i_xtcp, NUM_TCP_CLIENTS,
                           null, // mii_if
                           i_cfg[CFG_TO_TCP], i_rx[ETH_TO_TCP], i_tx[ETH_TO_TCP],
-                          mac_address_phy, null, ipconfig);
+                          ipconfig);
 
     on tile[1]: app_udp_connect(i_xtcp[TCP_TO_APP_UDP]);
   }

--- a/tests/xtcp_xcommon_build/Makefile
+++ b/tests/xtcp_xcommon_build/Makefile
@@ -5,11 +5,9 @@ TARGET = XCORE-200-EXPLORER
 
 APP_NAME =
 
-COMMON_FLAGS   = -O3 -mno-dual-issue -g -report -DBOARD_SUPPORT_BOARD=XK_EVK_XE216 ../config.xscope
+XCC_FLAGS  = -O3 -mno-dual-issue -g -report -DBOARD_SUPPORT_BOARD=XK_EVK_XE216 ../config.xscope
 
-XCC_FLAGS  = $(COMMON_FLAGS) -DXTCP_STACK_LWIP
-
-USED_MODULES = lib_xtcp lib_board_support lib_otpinfo
+USED_MODULES = lib_xtcp lib_board_support(>=1.4.0) lib_otpinfo(>=2.2.1)
 
 #=============================================================================
 # The following part of the Makefile includes the common build infrastructure

--- a/tests/xtcp_xcommon_build/src/main.xc
+++ b/tests/xtcp_xcommon_build/src/main.xc
@@ -42,6 +42,11 @@ xtcp_ipconfig_t ipconfig = {
 
 #define ETH_RX_BUFFER_SIZE_WORDS 1600
 
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  (void)netif_id;
+  otp_board_info_get_mac(otp_ports, 0, mac_address);
+}
+
 int main(void) {
   xtcp_if         i_xtcp[NUM_XTCP_CLIENTS];
   ethernet_cfg_if i_cfg[NUM_CFG_CLIENTS];
@@ -66,7 +71,7 @@ int main(void) {
     // TCP component
     on tile[0]: xtcp_lwip(i_xtcp, NUM_XTCP_CLIENTS, null,
                           i_cfg[CFG_TO_XTCP], i_rx[ETH_TO_XTCP], i_tx[ETH_TO_XTCP],
-                          null, otp_ports, ipconfig);
+                          ipconfig);
 
     // HTTP server application
     on tile[0]: xhttpd(i_xtcp[XTCP_TO_HTTP]);

--- a/tests/xtcp_xk_eth_316_dual_basic/src/main.xc
+++ b/tests/xtcp_xk_eth_316_dual_basic/src/main.xc
@@ -26,19 +26,24 @@ port p_phy_clk = RMII_PHY_CLK_50M;
 clock phy_rxclk = on tile[0]: XS1_CLKBLK_1;
 clock phy_txclk = on tile[0]: XS1_CLKBLK_2;
 
-// IP Config - change this to suit your network.  Leave with all 0 values to use DHCP/AutoIP
+// IP Config - change this to suit your network.  Leave with all 0 values to use DHCP
 xtcp_ipconfig_t ipconfig = {
-        { 192, 168, 200, 198 }, // ip address (eg 192,168,0,2)
-        { 255, 255, 255, 0 }, // netmask (eg 255,255,255,0)
-        { 0, 0, 0, 0 } // gateway (eg 192,168,0,1)
+  { 192, 168, 200, 198 }, // ip address (eg 192,168,0,2)
+  { 255, 255, 255, 0 }, // netmask (eg 255,255,255,0)
+  { 0, 0, 0, 0 } // gateway (eg 192,168,0,1)
 };
-// MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
-static const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
 
 #define ETH_RX_BUFFER_SIZE_WORDS 1600
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  // MAC address within the XMOS block of 00:22:97:xx:xx:xx. Please adjust to your desired address.
+  const unsigned char mac_address_phy[MACADDR_NUM_BYTES] = {0x00, 0x22, 0x97, 0x01, 0x02, 0x03};
+  (void)netif_id;
+  memcpy(mac_address, mac_address_phy, MACADDR_NUM_BYTES);
 }
 
 int main(void) {
@@ -76,7 +81,7 @@ int main(void) {
     on tile[0]: xtcp_lwip(i_xtcp, REFLECT_PROCESSES,
                           null, // mii_if
                           i_cfg[CFG_TO_XTCP], i_rx[ETH_TO_XTCP], i_tx[ETH_TO_XTCP],
-                          mac_address_phy, null, ipconfig);
+                          ipconfig);
     
     // The simple udp reflector thread
     par (int i = 0; i < REFLECT_PROCESSES; i++) {

--- a/tests/xtcp_xk_evk_xe216_basic/CMakeLists.txt
+++ b/tests/xtcp_xk_evk_xe216_basic/CMakeLists.txt
@@ -17,7 +17,11 @@ list(APPEND XC_SOURCES ${COMMON_SOURCES})
 
 set(APP_XC_SRCS ${XC_SOURCES})
 
-include(${CMAKE_CURRENT_LIST_DIR}/../deps.cmake)
+set(APP_DEPENDENT_MODULES   lib_xtcp
+                            "lib_board_support(1.4.0)"
+                            "lib_logging(3.4.0)"
+                            "lib_otpinfo(2.2.1)"
+                            )
 
 set(COMPILER_FLAGS_COMMON   -O3
                             -g

--- a/tests/xtcp_xk_evk_xe216_basic/src/main.xc
+++ b/tests/xtcp_xk_evk_xe216_basic/src/main.xc
@@ -21,11 +21,11 @@ rgmii_ports_t rgmii_ports = on tile[1]: RGMII_PORTS_INITIALIZER;
 port p_smi_mdio   = on tile[1]: XS1_PORT_1C;
 port p_smi_mdc    = on tile[1]: XS1_PORT_1D;
 
-// IP Config - change this to suit your network.  Leave with all 0 values to use DHCP/AutoIP
+// IP Config - change this to suit your network.  Leave with all 0 values to use DHCP
 xtcp_ipconfig_t ipconfig = {
-        { 192, 168, 210, 198 }, // ip address (eg 192,168,0,2)
-        { 255, 255, 255, 0 }, // netmask (eg 255,255,255,0)
-        { 0, 0, 0, 0 } // gateway (eg 192,168,0,1)
+  { 192, 168, 210, 198 }, // ip address (eg 192,168,0,2)
+  { 255, 255, 255, 0 }, // netmask (eg 255,255,255,0)
+  { 0, 0, 0, 0 } // gateway (eg 192,168,0,1)
 };
 
 // Defines
@@ -33,6 +33,11 @@ xtcp_ipconfig_t ipconfig = {
 
 void xscope_user_init(void) {
   xscope_mode_lossless();
+}
+
+void xtcp_configure_mac(unsigned netif_id, uint8_t mac_address[MACADDR_NUM_BYTES]) {
+  (void)netif_id;
+  otp_board_info_get_mac(otp_ports, 0, mac_address);
 }
 
 int main(void) {
@@ -60,7 +65,7 @@ int main(void) {
 
     on tile[0]: xtcp_lwip(i_xtcp, REFLECT_PROCESSES, null,
                           i_cfg[CFG_TO_XTCP], i_rx[ETH_TO_XTCP], i_tx[ETH_TO_XTCP],
-                          null, otp_ports, ipconfig);
+                          ipconfig);
 
     // The simple udp reflector thread
     par (int i = 0; i < REFLECT_PROCESSES; i++) {


### PR DESCRIPTION
Removed xtcp_lwip() parameters for MAC and OTP.

This removes dependency of lib_otpinfo from lib_xtcp.