### PR TITLE
add getsockopt() and setsockopt() APIs

### DIFF
--- a/lib_xtcp/api/xtcp.h
+++ b/lib_xtcp/api/xtcp.h
@@ -153,6 +153,33 @@ typedef enum xtcp_error_code_t
   XTCP_EINUSE = -5,           /**< Address in use */
 } xtcp_error_code_t;
 
+/** XTCP socket levels.
+ *
+ *  This type represents the socket levels for getsockopt() and
+ *  setsockopt().
+ *
+ *  Presently only XTCP_SOCKET_LEVEL_IP is supported.
+ */
+typedef enum xtcp_socket_level_t {
+  XTCP_SOCKET_LEVEL_IP = 0,     /**< IP */
+  XTCP_SOCKET_LEVEL_SOCKET = 1, /**< The socket itself */
+  XTCP_SOCKET_LEVEL_TCP = 6,    /**< TCP */
+  XTCP_SOCKET_LEVEL_UDP = 7,    /**< UDP */
+} xtcp_socket_level_t;
+
+/** XTCP socket options.
+ *
+ *  This type represents a socket option when calling getsockopt()
+ *  or setsockopt() with XTCP_SOCKET_LEVEL_IP.
+ */
+typedef enum xtcp_ip_socket_option_t {
+  XTCP_IP_SOCKET_OPTION_TOS = 1,  /**< TOS, value is uint8_t */
+  XTCP_IP_SOCKET_OPTION_TTL = 2,  /**< TTL, value is uint8_t */
+  XTCP_IP_SOCKET_OPTION_MULTICAST_TTL = 5,  /**< multicast TTL, value is uint8_t */
+  XTCP_IP_SOCKET_OPTION_MULTICAST_IF = 6,   /**< multicast interface index, value is uint8_t */
+  XTCP_IP_SOCKET_OPTION_MULTICAST_LOOP = 7, /**< multicast loopback, value is uint8_t */
+} xtcp_ip_socket_option_t;
+
 /** This type represents an int32_t with a status value.
  *
  *  This is a type used to return both a status code and an int32_t value.
@@ -440,6 +467,28 @@ typedef interface xtcp_if {
    * \note This is a non-blocking call. The result of the lookup will be indicated by an XTCP_DNS_RESULT event.
    */
   xtcp_host_t request_host_by_name(const uint8_t hostname[len], static_const_unsigned len, xtcp_ipaddr_t dns_server);
+
+  /** \brief Get a socket option
+   *
+   * \param id       The connection descriptor to act on.
+   * \param level    The protocol level to operate on.
+   * \param option   The socket option.
+   * \param value    The option value.
+   * \param length   The option value length.
+   * \returns        XTCP_SUCCESS if successful, XTCP_EINVAL if invalid parameters are provided.
+   */
+  xtcp_error_int32_t getsockopt(int32_t id, xtcp_socket_level_t level, uint32_t option, uint8_t value[length], static_const_unsigned length);
+
+  /** \brief Set a socket option
+   *
+   * \param id       The connection descriptor to act on.
+   * \param level    The protocol level to operate on.
+   * \param option   The socket option.
+   * \param value    The option value.
+   * \param length   The option value length.
+   * \returns        XTCP_SUCCESS if successful, XTCP_EINVAL if invalid parameters are provided.
+   */
+  xtcp_error_code_t setsockopt(int32_t id, xtcp_socket_level_t level, uint32_t option, const uint8_t value[length], static_const_unsigned length);
 
   /** \brief Query if the underlying interface is up.
    *

--- a/lib_xtcp/src/lwip_shim.h
+++ b/lib_xtcp/src/lwip_shim.h
@@ -6,6 +6,10 @@
 
 #include "xtcp.h"
 
+#ifdef __XC__
+extern "C" {
+#endif
+
 xtcp_error_int32_t shim_new_socket(unsigned client_num, xtcp_protocol_t protocol);
 void shim_close_socket(unsigned client_num, int32_t index);
 
@@ -23,5 +27,12 @@ xtcp_error_code_t shim_join_multicast_group(xtcp_ipaddr_t addr);
 xtcp_error_code_t shim_leave_multicast_group(xtcp_ipaddr_t addr);
 
 xtcp_host_t shim_request_host_by_name(unsigned client_num, const uint8_t hostname[], xtcp_ipaddr_t dns_server);
+
+xtcp_error_code_t shim_getsockopt(unsigned client_num, int32_t id, xtcp_socket_level_t level, uint32_t option, uint8_t value[], uint32_t *length);
+xtcp_error_code_t shim_setsockopt(unsigned client_num, int32_t id, xtcp_socket_level_t level, uint32_t option, ARRAY_OF_SIZE(const uint8_t, value, length), uint32_t length);
+
+#ifdef __XC__
+}
+#endif
 
 #endif /* XTCP_LWIP_SHIM_H */

--- a/lib_xtcp/src/xtcp_lwip.xc
+++ b/lib_xtcp/src/xtcp_lwip.xc
@@ -423,6 +423,27 @@ void xtcp_lwip(server xtcp_if i_xtcp[n_xtcp], static const unsigned n_xtcp,
         ipaddr = get_local_from_pcb(id);
         break;
 
+      case i_xtcp[unsigned i].getsockopt(int32_t id, xtcp_socket_level_t level, uint32_t option, uint8_t value[length], static_const_unsigned length) -> xtcp_error_int32_t error:
+        uint8_t value_copy[length];
+        uint32_t length_copy = length;
+
+        error.status = shim_getsockopt(i, id, level, option, value_copy, &length_copy);
+        if (error.status == XTCP_SUCCESS) {
+            memcpy(value, value_copy, length_copy);
+            error.value = length_copy;
+        } else {
+            error.value = 0;
+        }
+
+        break;
+
+      case i_xtcp[unsigned i].setsockopt(int32_t id, xtcp_socket_level_t level, uint32_t option, const uint8_t value[length], static_const_unsigned length) -> xtcp_error_code_t result:
+        uint8_t value_copy[length];
+
+        memcpy(value_copy, value, length);
+        result = shim_setsockopt(i, id, level, option, value_copy, length);
+        break;
+
       case i_xtcp[unsigned i].is_ifup(void) -> int result:
         result = get_if_state();
         break;


### PR DESCRIPTION
Without importing the lwIP socket library, add getsockopt() and setsockopt() functions for setting IP TOS and TTL values in the PCB.