### PR TITLE
Add Makefile option for application set parameter LWIP_OPTS_PATH

### DIFF
--- a/lib_xtcp/module_build_info
+++ b/lib_xtcp/module_build_info
@@ -5,12 +5,17 @@ DEPENDENT_MODULES = lib_ethernet(>=4.1.0) lib_otpinfo(>=2.2.1) lib_random(>=1.3.
 # Build flags
 MODULE_XCC_FLAGS = $(XCC_FLAGS) -g -O3 -mno-dual-issue -DSSIZE_MAX=INT_MAX
 
+ifndef LWIP_OPTS_PATH
+$(warning "LWIP_OPTS_PATH not defined, setting to 'standard', may be overridden in the application's Makefile")
+LWIP_OPTS_PATH = ../lwip/contrib/ports/xmos/lib/standard
+endif
+
 # Source directories
 # Note: only includes IPv4 of lwIP
 LWIP_SOURCE_DIRS = ../lwip/api ../lwip/src/api ../lwip/src/core ../lwip/src/core/ipv4 ../lwip/src/netif ../lwip/contrib/ports/xmos/port
 
 # Include directories
-LWIP_INCLUDE_DIRS = ../lwip/src/include ../lwip/contrib ../lwip/contrib/ports/xmos/include ../lwip/contrib/ports/xmos/lib/standard
+LWIP_INCLUDE_DIRS = ../lwip/src/include ../lwip/contrib ../lwip/contrib/ports/xmos/include $(LWIP_OPTS_PATH)
 
 # Exclude files
 LWIP_EXCLUDE_FILES += slipif.c

--- a/tests/xtcp_xcommon_build/Makefile
+++ b/tests/xtcp_xcommon_build/Makefile
@@ -5,6 +5,8 @@ TARGET = XCORE-200-EXPLORER
 
 APP_NAME =
 
+LWIP_OPTS_PATH = ../lwip/contrib/ports/xmos/lib/standard
+
 XCC_FLAGS  = -O3 -mno-dual-issue -g -report -DBOARD_SUPPORT_BOARD=XK_EVK_XE216 ../config.xscope
 
 USED_MODULES = lib_xtcp lib_board_support(>=1.4.0) lib_otpinfo(>=2.2.1)


### PR DESCRIPTION
If LWIP_OPTS_PATH not set in apllicaiton Makefile, the library Makefile will set it to standard/lwipopts.h (and warn about it).

In the application set the parameter as follows, please note path is relative to folder <sandbox>/lib_xtcp/lib_xtcp/
To reference the library standard options;
`LWIP_OPTS_PATH = ../lwip/contrib/ports/xmos/lib/standard`

To reference the an applicaiton relative options file (reccommend taking a copy of `standard` or `minimal` files from the library);
`LWIP_OPTS_PATH = ../../<application>/<path-to-folder-containing-copy-of-lwipopts.h>`